### PR TITLE
Feature/v0.0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,157 @@
-# NyanQL
+# NyanQL（にゃんくる）
 
-NyanQL（にゃんくる）は、SQL を実行して JSON を返す API サービスです。
+NyanQL（にゃんくる）は、SQLを書くだけで、データベースにアクセスするAPIサービスを手軽に作るための軽量フレームワークです。
 
-内部に保存された SQL ファイルや JavaScript ファイルを API 設定により選択し、実行結果を JSON 形式で返します。さらに、Push 機能を利用すると、ある API の実行結果を WebSocket 経由で別のクライアントに自動配信できます。
+「猫の手も借りたい」くらい忙しい業務システム開発で、APIサーバ作りの手間を小さくし、まずは大事なSQLに集中できるようにすることを目指しています。
 
-NyanQL には以下の機能があります：
-
-- **SQL 実行**：動的パラメータ置換、条件分岐ブロック対応
-- **JavaScript スクリプト実行**（`script`）：自由に JSON を生成
-- **リクエスト検証**（`check`）：入力パラメータの事前検証
-- **WebSocket Push**：別 API へのリアルタイム配信
-
-関連プロジェクト：
-
-- **Nyan8**（にゃんぱち）：JavaScript 実行で JSON 生成
-- **NyanPUI**（にゃんぷい）：HTML 生成
+NyanQLでは、APIを呼び出すと、`api.json` に紐づけられたSQLファイル、またはJavaScriptファイルが実行されます。SQLの実行結果はJSONで返ります。検索だけでなく、登録・更新・削除、複数SQLのトランザクション、JavaScriptによる複雑な処理、WebSocketによるPush配信にも対応しています。
 
 ---
 
-## 目次
+## NyanQLでできること
 
-1. [対応データベース](#対応データベース)
-2. [インストールと実行](#インストールと実行)
-3. [設定ファイル](#設定ファイル)
-    - [config.json](#configjson)
-    - [api.json](#apijson)
-4. [SQL テンプレート構文](#sql-テンプレート構文)
-    - [パラメータ置換](#パラメータ置換)
-    - [条件分岐ブロック](#条件分岐ブロック)
-5. [JavaScript Script / Check](#javascript-script--check)
-6. [ファイル操作ユーティリティ](#ファイル操作ユーティリティ)
-7. [サーバ情報取得エンドポイント](#サーバ情報取得エンドポイント)
-8. [レスポンス形式](#レスポンス形式)
-9. [アクセス方法](#アクセス方法)
-10. [JSON-RPC サポート](#json-rpc-サポート)
-11. [トランザクション](#トランザクション)
-12. [予約語](#予約語)
+NyanQLは、主に次のような用途に向いています。
+
+- SQLを中心にして、データベース用のAPIをすばやく作る
+- SELECTの結果をJSONとして返すAPIを作る
+- INSERT、UPDATE、DELETEなどの更新処理をAPI化する
+- 複数のSQLを1つのトランザクションとしてまとめて実行する
+- JavaScriptで、SQLだけでは書きにくい一連の処理をまとめる
+- WebSocketを使って、API実行後の結果を別の画面へPush配信する
+- `/nyan` で、利用できるAPIの情報を取得する
+
+NyanQLは、画面を作るためのフレームワークではありません。役割は、データベースアクセスに特化したAPIサービスを作ることです。
+
+---
+
+## 基本の考え方：SQLファースト
+
+NyanQLは「SQLファースト」という考え方を大事にしています。
+
+まず、単体で正しく動くSQLを書きます。次に、そのSQLファイルを `api.json` でAPI名に紐づけます。すると、HTTPからAPIを呼び出したときに、そのSQLが実行され、結果がJSONで返ります。
+
+流れはとてもシンプルです。
+
+1. SQLファイルを書く
+2. `api.json` にAPI定義を書く
+3. API名とSQLファイルを紐づける
+4. HTTP、またはJSON-RPCでAPIを呼び出す
+5. 実行結果をJSONで受け取る
+
+たとえば、次のようなSQLを書きます。
+
+```sql
+SELECT
+  id AS id,
+  name AS name,
+  price AS price
+FROM items
+WHERE id = /*id*/1;
+```
+
+そして、`api.json` に次のように書きます。
+
+```json
+{
+  "getItem": {
+    "sql": ["./sql/getItem.sql"],
+    "description": "商品を1件取得します"
+  }
+}
+```
+
+この状態で、次のように呼び出せます。
+
+```bash
+curl -u admin:secret "http://localhost:8080/getItem?id=1"
+```
+
+返り値は、次のようなJSONになります。
+
+```json
+{
+  "success": true,
+  "status": 200,
+  "result": [
+    {
+      "id": 1,
+      "name": "にゃんくるTシャツ",
+      "price": 3000
+    }
+  ]
+}
+```
+
+SELECT句の `AS` で指定した列名が、そのままJSONの項目名になります。
 
 ---
 
 ## 対応データベース
+
+現在の実装では、次のデータベースに対応しています。
 
 - MySQL
 - PostgreSQL
 - SQLite
 - DuckDB
 
----
-
-## インストールと実行
-
-1. GitHub Releases からホスト OS に合わせた ZIP をダウンロード
-2. `config.json` と `api.json` を編集
-3. ターミナル または ダブルクリックで実行
-
-> リリース: https://github.com/NyanQL/NyanQL/releases
+`config.json` の `DBType` に、`mysql`、`postgres`、`sqlite`、`duckdb` のいずれかを指定します。
 
 ---
 
-## 設定ファイル
+## インストールと起動
 
-### config.json
+### 1. 入手する
 
-NyanQL サーバの全体設定を記述します。
+GitHub Releasesから、使っているOSに合うファイルをダウンロードします。
+
+https://github.com/NyanQL/NyanQL/releases
+
+ソースからビルドする場合は、Goの開発環境を用意してからビルドしてください。
+
+```bash
+git clone https://github.com/NyanQL/NyanQL.git
+cd NyanQL
+go build -o nyanql
+```
+
+### 2. 設定ファイルを用意する
+
+NyanQLの実行ファイルと同じ場所に、少なくとも次の2つのファイルを置きます。
+
+- `config.json`
+- `api.json`
+
+SQLファイルやJavaScriptファイルも、`api.json` から参照できる場所に置いてください。
+
+### 3. 起動する
+
+```bash
+./nyanql
+```
+
+Windowsでは、ビルド済みの実行ファイルをダブルクリックして起動することもできます。ただし、動作確認やエラー確認をしやすくするため、最初はターミナルから起動することをおすすめします。
+
+---
+
+## config.json
+
+`config.json` には、サーバ全体の設定を書きます。
 
 ```json
 {
-  "name": "API サーバ名",
-  "profile": "サーバの概要説明",
+  "name": "NyanQL Sample API",
+  "profile": "NyanQLのサンプルAPIです",
   "version": "v1.0.0",
   "Port": 8080,
-  "CertPath": "./cert.pem",
-  "KeyPath": "./key.pem",
-  "DBType": "postgres",
-  "DBUser": "user",
-  "DBPassword": "pass",
-  "DBName": "dbname",
+  "CertPath": "",
+  "KeyPath": "",
+  "DBType": "sqlite",
+  "DBUser": "",
+  "DBPassword": "",
+  "DBName": "./stamps.db",
   "DBHost": "localhost",
-  "DBPort": "5432",
+  "DBPort": "",
   "MaxOpenConnections": 10,
   "MaxIdleConnections": 5,
   "ConnMaxLifetimeSeconds": 300,
@@ -94,314 +168,626 @@ NyanQL サーバの全体設定を記述します。
     "EnableLogging": true
   },
   "javascript_include": [
-    "./javascript/lib/nyanRequestCheck.js",
     "./javascript/common.js"
   ]
 }
 ```
 
-- **Port**: HTTP/HTTPS ポート
-- **CertPath/KeyPath**: SSL 証明書（HTTPS 有効化）
-- **DBType**: `mysql` | `postgres` | `sqlite` | `duckdb`
-- **接続プール**: `MaxOpenConnections` / `MaxIdleConnections` / `ConnMaxLifetimeSeconds`
-- **BasicAuth**: ベーシック認証の設定
-- **javascript_include**: `check` や `script` 実行前に読み込む JS
+主な項目は次のとおりです。
 
-<details>
-<summary>ログ設定項目の説明</summary>
+| 項目 | 説明 |
+|---|---|
+| `name` | `/nyan` で返すサーバ名です。 |
+| `profile` | `/nyan` で返すサーバ説明です。 |
+| `version` | `/nyan` で返す設定上のバージョンです。 |
+| `Port` | NyanQLが待ち受けるポート番号です。 |
+| `CertPath`, `KeyPath` | 両方を指定するとHTTPSで起動します。空ならHTTPで起動します。 |
+| `DBType` | `mysql`、`postgres`、`sqlite`、`duckdb` のいずれかを指定します。 |
+| `DBName` | データベース名、またはSQLite/DuckDBのファイルパスです。 |
+| `BasicAuth` | API呼び出し時のBasic認証ユーザ名とパスワードです。 |
+| `javascript_include` | `check` や `script` の実行前に読み込む共通JavaScriptです。 |
 
-* **Filename** – 出力先ファイルパス
-* **MaxSize** – 1 ファイルの上限サイズ（MB）
-* **MaxBackups** – 保持世代数
-* **MaxAge** – 保持日数
-* **Compress** – 過去ファイルを gzip 圧縮
-* **EnableLogging** – false で標準出力のみ
-
-</details>
+SQLiteとDuckDBでは、`DBName` に相対パスを書いた場合、実行ファイルがある場所を基準にして扱われます。
 
 ---
 
-### api.json
+## api.json
 
-各 API エンドポイントごとに実行する SQL/スクリプトを定義します。
+`api.json` には、API名と、実行するSQLまたはJavaScriptの対応を書きます。
+
+### SQLを実行するAPI
 
 ```json
 {
-  "list": {
-    "sql": ["./sql/sqlite/list.sql"],
-    "description": "当月の一覧を表示します。"
-  },
-  "check": {
-    "check": "./javascript/check.js",
-    "sql": ["./sql/sqlite/checkDay.sql"],
-    "description": "パラメータ検証と検索を同時に行います。"
-  },
-  "stamp": {
-    "sql": ["./sql/sqlite/insert_stamp.sql"],
-    "description": "本日のスタンプを記録します。",
-    "push": "list"
+  "listItems": {
+    "sql": ["./sql/listItems.sql"],
+    "description": "商品一覧を取得します"
   }
 }
 ```
 
-#### type と WebSocket クライアント（ws_client）
+この例では、`/listItems` または `/?api=listItems` を呼び出すと、`./sql/listItems.sql` が実行されます。
 
-- `type` を省略した場合は従来通り HTTP/WS サーバーの API (`"type": "api"`) として動作します。
-- `type: "ws_client"` を指定すると NyanQL 自身が WebSocket クライアントになり、起動時に常時接続します。
-- `connectURL` が `env:XXXX` の場合、環境変数 `XXXX` で接続 URL を解決します。
+### checkで入力を確認してからSQLを実行するAPI
 
-```json
-"websocket_clients_local": {
-  "type": "ws_client",
-  "script": "./javascript/ws/receiver_main.js",
-  "connectURL": "ws://localhost:8890/hello",
-  "description": "ローカル動作確認用（自身の /hello に接続）"
-}
-```
-
-受信したメッセージは `script` で指定した JavaScript に `nyanAllParams` として渡され、戻り値がそのまま上流の WebSocket へ送信されます（空文字を返すと返信しません）。
-
----
-
-## トランザクション
-
-NyanQL は、1つの API 呼び出しの中で複数の SQL を実行する場合、**それらを1つのトランザクションとしてまとめて実行**します。  
-これにより、途中でエラーが発生した場合は **それまでの変更がすべてロールバック**され、データの整合性を保てます。
-
-注:
-- 1SQL でも「必ずトランザクションにしたい」場合は、`script` を使うか、SQL を分割して複数指定してください。
-- `check` はトランザクション開始前に実行されます。`check` が失敗した場合、SQL / script は実行されません。
-- 「失敗」とは、`nyanRunSQL()` の実行エラー、またはスクリプト実行時の例外（panic）など、Go 側でエラーとして扱われる状態を指します。
-
-### SQL 配列（api.json の `sql`）のトランザクション
-
-`api.json` の `sql` が **2ファイル以上**指定されている場合、NyanQL は実行開始時に DB トランザクションを開始します。
-
-- **開始**: API 実行の先頭で `BEGIN`
-- **実行**: 配列に並んだ SQL を上から順に同一トランザクション内で実行
-- **成功**: 全て成功したら `COMMIT`
-- **失敗**: Go 側でエラーとして扱われた場合は `ROLLBACK`（以降の SQL は実行されません）
-
-※ `sql` が **1ファイルのみ**の場合は、通常はトランザクションを開始しません（DB の自動コミット動作になります）。
-
-### script（JavaScript）実行時のトランザクション
-
-`api.json` で `script` が指定されている場合、NyanQL はスクリプト実行の先頭でトランザクションを開始し、  
-VM に `nyanTx` として渡します。スクリプト内で `nyanRunSQL()` を複数回呼んでも **同一トランザクション内**で実行されます。
-
-- **開始**: `script` 実行開始時に `BEGIN`
-- **実行**: `nyanRunSQL()` は `nyanTx` を使って Query/Exec
-- **成功**: スクリプトが最後まで成功したら `COMMIT`
-- **失敗**: Go 側でエラーとして扱われた場合は `ROLLBACK`
-
-### JSON-RPC のトランザクション
-
-JSON-RPC（`/nyan-rpc`）でも HTTP と同様に、`sql` が複数指定されている場合はトランザクションでまとめて実行されます。
-
----
-
-## SQL テンプレート構文
-
-### パラメータ置換 
-
-```sql
-SELECT count(id) AS this_days_count
-FROM stamps
-WHERE date = /*date*/'2025-02-15';
-```
-
-リクエスト `?date=2024-02-15` で動的に置換されます。
-
-### 条件分岐ブロック
-
-```sql
-SELECT id, date FROM stamps
-/*BEGIN*/
- WHERE
-   /*IF id != null*/ id = /*id*/1 /*END*/
-   /*IF date != null*/ AND date = /*date*/'2024-06-25' /*END*/
-/*END*/;
-```
-
-条件に応じて WHERE 部分が自動展開されます。
-
----
-
-## JavaScript Script / Check
-
-- **check**: 入力検証用の JS。`success` / `status` / `error` を持つ JSON 文字列を返します。失敗時の例: `{ success:false, status:401, error:{ message: "..." }}`。
-- **script**: 自由に JSON を生成。`nyanRunSQL` や `nyanAllParams` が利用可能。
-- **nyan_mode=checkOnly**: HTTP リクエストまたは JSON-RPC で `nyan_mode=checkOnly` パラメータを指定すると、`check` スクリプトのみを実行し、その結果を返します。`script` や SQL の実行は行われません。`push` が設定されている API では、`check` 成功時に Push は実行されます。
-
-### `nyanGetAPI / nyanJsonAPI / nyanCallAPI`
-
-JavaScript の `script` / `check` から外部 API を呼び出します。
-
-- `nyanGetAPI(url, username, password)` は GET リクエストを送信します。
-- `nyanJsonAPI(url, jsonData, username, password, headers)` は JSON を POST します。
-- `nyanCallAPI(url, jsonData, username, password, headers)` は `nyanJsonAPI()` のラッパーで、引数と挙動は同じです。
-
-`jsonData` には JSON 文字列を渡してください。JavaScript オブジェクトを送る場合は `JSON.stringify()` してください。  
-`headers` は省略可能で、オブジェクトまたは JSON 文字列で指定できます。
-
-```js
-const getResponse = nyanGetAPI("https://api.example.com/data", "nyan", "password");
-console.log("GET Response:", getResponse);
-
-const postData = JSON.stringify({ key: "value" });
-const jsonResponse = nyanJsonAPI(
-  "https://api.example.com/update",
-  postData,
-  "nyan",
-  "password"
-);
-const callResponse = nyanCallAPI(
-  "https://api.example.com/update",
-  postData,
-  "nyan",
-  "password"
-);
-console.log("POST Response:", jsonResponse);
-console.log("POST Response via wrapper:", callResponse);
-```
-
-header を追加したい場合は第 5 引数に指定してください。
-
-```js
-const headers = {
-  "Content-Type": "application/json",
-  "X-Custom-Header": "CustomValue"
-};
-
-const response = nyanCallAPI(
-  "https://api.example.com/data",
-  postData,
-  "nyan",
-  "password",
-  headers
-);
-```
-
-### `nyanCallMe(params: object): any`
-
-JavaScript の `script` / `check` 内から、`api.json` に定義された別 API（`type: "api"`）を内部実行します。
-
-- `params.api` に呼び出し先 API 名を指定します。
-- 呼び出し先 API は `check` / `script` / `sql` の定義に従って、通常 API 呼び出しと同じ流れで実行されます。
-- `params.nyan_mode = "checkOnly"` を指定すると、呼び出し先 API の `check` のみ実行します。`push` が設定されている API では、`check` 成功時に Push は実行されます。
-- `params` の内容は呼び出し先 `nyanAllParams` として渡されます。
-- 返り値が JSON として解釈できる場合は、その JSON 値を返します。JSON として解釈できない場合は文字列を返します。
-- 引数は必須で `object` のみ受け付けます（それ以外はエラーになります）。
-- `params.api` は必須で、省略または空文字の場合はエラーになります。
-
-```js
-function main() {
-  const res = nyanCallMe({
-    api: "sub_task",
-    user_id: nyanAllParams.user_id
-  });
-
-  return JSON.stringify({
-    success: true,
-    status: 200,
-    result: res
-  });
-}
-```
-
----
-
-## ファイル操作ユーティリティ
-
-### `nyanBase64Encode(data: string): string`
-文字列を Base64 エンコードして返します。
-
-### `nyanBase64Decode(b64: string): string`
-Base64 をデコードして元の文字列を返します。
-
-### `nyanSaveFile(b64: string, destPath: string)`
-エンコード済み Base64 をデコードし、`destPath` にファイル保存します。相対パスは実行ファイルのディレクトリ基準で解決され、親ディレクトリが無ければ自動作成されます。
-
-```js
-const raw = "こんにちは！ にゃんくる";
-const b64 = nyanBase64Encode(raw);
-nyanSaveFile(b64, "./storage/hello.txt");
-```
-
----
-
-## サーバ情報取得エンドポイント
-
-### `GET /nyan`
-サーバの基本情報と利用可能な API 一覧を取得します。
-
-**レスポンス例**
 ```json
 {
-  "name": "API サーバ名",
-  "profile": "サーバの概要説明",
-  "version": "v1.0.0",
-  "apis": {
-    "list": { "description": "当月の一覧を表示します。" },
-    "stamp": { "description": "本日のスタンプを記録します。" }
+  "getItem": {
+    "check": "./javascript/checkGetItem.js",
+    "sql": ["./sql/getItem.sql"],
+    "description": "商品を1件取得します"
   }
 }
 ```
 
-### `GET /nyan/{API名}`
-指定した API の詳細情報（説明、受け入れ可能パラメータ、出力カラム）を取得します。
+`check` に指定したJavaScriptが先に実行されます。ここでエラーを返すと、SQLは実行されません。
 
-**レスポンス例**
+### scriptを実行するAPI
+
 ```json
 {
-  "api": "list",
-  "description": "当月の一覧を表示します。",
-  "nyanAcceptedParams": { "date": "2024-06-25" },
-  "nyanOutputColumns": ["id", "date"]
+  "createOrder": {
+    "check": "./javascript/checkCreateOrder.js",
+    "script": "./javascript/createOrder.js",
+    "description": "注文伝票を1件登録します"
+  }
 }
 ```
+
+`script` を指定したAPIでは、JavaScriptファイルを実行します。この場合、同じAPI定義の中に `sql` は書けません。実装上、`script` と `sql` を同時に指定すると起動時にエラーになります。
+
+---
+
+## APIの呼び出し方
+
+NyanQLのAPIは、主に次の形で呼び出せます。
+
+```bash
+curl -u admin:secret "http://localhost:8080/listItems"
+```
+
+```bash
+curl -u admin:secret "http://localhost:8080/?api=listItems"
+```
+
+POSTでJSONを送る場合は、`Content-Type: application/json` を指定します。
+
+```bash
+curl -u admin:secret \
+  -H "Content-Type: application/json" \
+  -d '{"api":"getItem","id":1}' \
+  "http://localhost:8080/"
+```
+
+URLのパスにAPI名を書いた場合、NyanQLはそのパスをAPI名として扱います。たとえば `/getItem?id=1` は、`api=getItem` として扱われます。
 
 ---
 
 ## レスポンス形式
 
-### 成功時
+SQL実行が成功した場合は、次の形式で返ります。
 
 ```json
 {
   "success": true,
   "status": 200,
-  "result": [...]
+  "result": []
 }
 ```
 
-### エラー時
+`SELECT` や `RETURNING` を含むSQLでは、`result` に検索結果の配列が入ります。
+
+```json
+{
+  "success": true,
+  "status": 200,
+  "result": [
+    { "id": 1, "name": "にゃんくる" }
+  ]
+}
+```
+
+`INSERT`、`UPDATE`、`DELETE` など、行を返さないSQLでは、現在の実装では `result` は空のオブジェクトになります。
+
+```json
+{
+  "success": true,
+  "status": 200,
+  "result": {}
+}
+```
+
+エラー時は、次のような形式で返ります。
 
 ```json
 {
   "success": false,
   "status": 500,
-  "error": { "message": "..." }
+  "error": {
+    "message": "Error executing SQL query"
+  }
 }
 ```
 
 ---
 
-## アクセス方法
+## 2way-SQLによる動的SQL
 
-- HTTP: `http://localhost:{Port}/?api=API名`
-- HTTPS: `https://localhost:{Port}/?api=API名`
-- エンドポイント形式: `/API名` も同様
+NyanQLでは、SQLコメントの中にパラメータ名を書けます。この書き方は、S2Daoなどで使われてきた2way-SQLの考え方を参考にしています。
+
+2way-SQLとは、SQLツールなどでそのまま実行できるSQLを書きながら、アプリから実行するときにはコメント部分をパラメータとして差し替える書き方です。
+
+### パラメータ置換
+
+```sql
+SELECT
+  id AS id,
+  name AS name
+FROM items
+WHERE id = /*id*/1;
+```
+
+`id=10` を指定してAPIを呼び出すと、NyanQLは `/*id*/1` の部分をプレースホルダーに変換し、値として `10` を渡します。
+
+PostgreSQLでは `$1`、それ以外のデータベースでは `?` の形のプレースホルダーに変換されます。
+
+### 配列パラメータ
+
+リクエスト値が配列の場合、NyanQLは `IN` 句などで使えるように、複数のプレースホルダーへ展開します。
+
+```sql
+SELECT
+  id AS id,
+  name AS name
+FROM items
+WHERE id IN (/*ids*/1);
+```
+
+たとえば、JSONで次のように送れます。
+
+```json
+{
+  "api": "listItemsByIds",
+  "ids": [1, 2, 3]
+}
+```
+
+GETのクエリ文字列では、`ids=1,2,3` のようにカンマ区切りで渡すこともできます。
+
+### JSONパラメータ
+
+リクエスト値がオブジェクトの場合、NyanQLはJSON文字列に変換して、SQLの1つの値として渡します。PostgreSQLのJSONB列などへ渡すときに使えます。
 
 ---
 
-## JSON-RPC サポート
+## 条件つきSQL
 
-- エンドポイント: `/nyan-rpc`
-- JSON-RPC 2.0 準拠(batchは未実装)
+検索条件があるときだけWHERE句を出したい場合は、`/*BEGIN*/` と `/*IF ...*/` を使います。
+
+```sql
+SELECT
+  id AS id,
+  name AS name,
+  category AS category
+FROM items
+/*BEGIN*/
+WHERE
+  /*IF id != null*/ id = /*id*/1 /*END*/
+  /*IF category != null*/ AND category = /*category*/'book' /*END*/
+/*END*/;
+```
+
+`id` や `category` が指定されていない場合、その条件は出力されません。
+
+現在の実装で使える条件は、主に次の形です。
+
+```sql
+/*IF id != null*/ ... /*END*/
+/*IF id == null*/ ... /*END*/
+```
+
+`AND` と `OR` を使った条件判定にも対応しています。ただし、複雑な式を自由に評価するものではありません。基本は「値があるか、ないか」を見てSQLの一部を出し分ける機能として使うのが安全です。
+
+---
+
+## `/nyan` でAPI情報を見る
+
+NyanQLでは、APIの一覧や、各APIが受け取るパラメータ情報を確認できます。
+
+### API一覧を見る
+
+```bash
+curl -u admin:secret "http://localhost:8080/nyan/"
+```
+
+返り値の例です。
+
+```json
+{
+  "name": "NyanQL Sample API",
+  "profile": "NyanQLのサンプルAPIです",
+  "version": "v1.0.0",
+  "apis": {
+    "listItems": {
+      "description": "商品一覧を取得します"
+    },
+    "getItem": {
+      "description": "商品を1件取得します"
+    }
+  }
+}
+```
+
+### APIごとの詳細を見る
+
+```bash
+curl -u admin:secret "http://localhost:8080/nyan/getItem"
+```
+
+返り値の例です。
+
+```json
+{
+  "api": "getItem",
+  "description": "商品を1件取得します",
+  "nyanAcceptedParams": {
+    "id": 1
+  },
+  "nyanOutputColumns": []
+}
+```
+
+SQL内の `/*id*/1` のようなコメントから、受け付けるパラメータを拾います。これにより、API利用者は「どんなパラメータを渡せばよいか」を確認しやすくなります。
+
+`script` を使うAPIでは、JavaScriptファイル内に次の定数を書くと、`/nyan/{API名}` の情報に反映できます。
+
+```js
+const nyanAcceptedParams = {
+  order_no: "A-001",
+  details: [
+    { item_id: 1, quantity: 2 }
+  ]
+};
+
+const nyanOutputColumns = ["order_id", "order_no"];
+```
+
+---
+
+## 入力チェック：check
+
+`check` は、SQLやscriptを実行する前に、リクエスト内容を確認するためのJavaScriptです。
+
+たとえば、`id` が指定されていない場合にエラーを返すには、次のように書きます。
+
+```js
+if (!nyanAllParams.id) {
+  JSON.stringify({
+    success: false,
+    status: 400,
+    error: {
+      message: "idを指定してください"
+    }
+  });
+} else {
+  JSON.stringify({
+    success: true,
+    status: 200,
+    error: null
+  });
+}
+```
+
+`check` の戻り値は、JSON文字列にしてください。NyanQLは、そのJSONを読んで、`success` が `true` なら次の処理へ進みます。`false` の場合は、SQLやscriptを実行せずにエラーを返します。
+
+### checkだけを実行する
+
+`nyan_mode=checkOnly` を指定すると、`check` だけを実行できます。
+
+```bash
+curl -u admin:secret "http://localhost:8080/getItem?id=1&nyan_mode=checkOnly"
+```
+
+入力フォームの事前チェックなどに使えます。
+
+---
+
+## JavaScriptによる処理：script
+
+SQLだけでは書きにくい一連の処理は、`script` にまとめられます。
+
+たとえば「注文ヘッダを1件登録し、注文明細を複数件登録する」という処理では、受け取ったJSONの明細配列をJavaScriptでループし、その中でSQLを実行できます。
+
+`api.json` の例です。
+
+```json
+{
+  "createOrder": {
+    "check": "./javascript/checkCreateOrder.js",
+    "script": "./javascript/createOrder.js",
+    "description": "注文伝票を1件登録します"
+  }
+}
+```
+
+`script` の例です。
+
+```js
+var order = nyanAllParams.order;
+
+var headerResult = nyanRunSQL("./sql/insertOrderHeader.sql", {
+  order_no: order.order_no,
+  customer_id: order.customer_id
+});
+
+for (var i = 0; i < order.details.length; i++) {
+  var detail = order.details[i];
+  nyanRunSQL("./sql/insertOrderDetail.sql", {
+    order_no: order.order_no,
+    item_id: detail.item_id,
+    quantity: detail.quantity
+  });
+}
+
+JSON.stringify({
+  success: true,
+  status: 200,
+  result: {
+    message: "注文を登録しました"
+  }
+});
+```
+
+`script` の実行中は、NyanQLがトランザクションを開始します。`nyanRunSQL()` で実行したSQLは、同じトランザクションの中で処理されます。途中でエラーが起きた場合はロールバックされます。
+
+---
+
+## JavaScriptで使える主な変数と関数
+
+`check` と `script` の中では、次の変数や関数を使えます。
+
+| 名前 | 説明 |
+|---|---|
+| `nyanAllParams` | リクエストで受け取ったパラメータ全体です。 |
+| `nyanAcceptedParamsKeys` | SQLコメントから拾った受け付けパラメータ名です。主にcheckで使います。 |
+| `nyanRunSQL(path, params)` | SQLファイルを実行します。scriptでは同じトランザクション内で実行されます。 |
+| `nyanGetAPI(url, user, pass)` | 外部APIへGETリクエストを送ります。 |
+| `nyanJsonAPI(url, jsonText, user, pass, headers)` | 外部APIへJSONをPOSTします。 |
+| `nyanCallAPI(...)` | `nyanJsonAPI` と同じ動きをする別名です。 |
+| `nyanCallMe(params)` | `api.json` に定義した別のAPIを内部呼び出しします。 |
+| `nyanGetFile(path)` | 実行ファイルの場所を基準にファイルを読みます。存在しない場合は `null` を返します。 |
+| `nyanBase64Encode(text)` | 文字列をBase64に変換します。 |
+| `nyanBase64Decode(base64)` | Base64を文字列に戻します。 |
+| `nyanSaveFile(base64, path)` | Base64文字列をデコードしてファイルに保存します。 |
+| `sha256(text)` | SHA-256のハッシュ文字列を返します。 |
+| `sha1(text)` | SHA-1のハッシュ文字列を返します。 |
+| `nyanHostExec(command)` | OSのコマンドを実行します。利用する場合は十分に注意してください。 |
+
+`nyanHostExec` は、サーバ上でOSコマンドを実行できる強い機能です。公開環境や、外部から入力を受ける処理では、安易に使わないでください。
+
+---
+
+## 複数SQLのトランザクション
+
+`api.json` の `sql` に複数のSQLファイルを指定すると、NyanQLはそれらを1つのトランザクションとして実行します。
+
+たとえば「入庫テーブルに追加し、在庫テーブルを更新する」という処理は、次のように書けます。
+
+```json
+{
+  "addItem": {
+    "sql": [
+      "./sql/insertNyuko.sql",
+      "./sql/updateZaiko.sql"
+    ],
+    "description": "商品を1件入庫します"
+  }
+}
+```
+
+この場合、1つ目のSQLと2つ目のSQLは同じトランザクションで実行されます。途中でエラーが起きると、全体がロールバックされます。
+
+現在の実装では、`sql` が1つだけの場合は明示的なトランザクションを開始しません。データベース側の通常の自動コミット動作になります。
+
+---
+
+## scriptでのトランザクション
+
+`script` を使うAPIでは、NyanQLがscript実行の開始時にトランザクションを開始します。
+
+script内で `nyanRunSQL()` を何度呼んでも、同じトランザクションの中で実行されます。scriptが最後まで正常に終わるとコミットされます。scriptの実行でエラーが起きた場合はロールバックされます。
+
+複雑な登録処理をひとまとまりにしたい場合は、複数SQLの配列よりも `script` が向いています。
+
+---
+
+## WebSocketによるPush配信
+
+NyanQLには、APIの実行後に別APIの結果をWebSocketへ配信するPush機能があります。
+
+たとえば、画面Aで「登録API」を呼び出した後、画面Bに「一覧API」の最新結果を送る、という使い方ができます。
+
+### Pushの基本
+
+`api.json` のAPI定義に `push` を書きます。
+
+```json
+{
+  "listItems": {
+    "sql": ["./sql/listItems.sql"],
+    "description": "商品一覧を取得します"
+  },
+  "addItem": {
+    "sql": ["./sql/insertItem.sql"],
+    "description": "商品を追加します",
+    "push": "listItems"
+  }
+}
+```
+
+この例では、`addItem` が実行されたあと、NyanQLは `listItems` を実行し、その結果を `listItems` チャネルに接続しているWebSocketクライアントへ配信します。
+
+WebSocketクライアントは、次のように接続します。
+
+```js
+var ws = new WebSocket("ws://localhost:8080/listItems");
+
+ws.onmessage = function (event) {
+  var data = JSON.parse(event.data);
+  console.log("Pushを受信しました", data);
+};
+```
+
+NyanQLのWebSocketサーバでは、URLパスの末尾がチャネル名になります。上の例では、`listItems` がチャネル名です。
+
+### Pushで配信される内容
+
+`push` の参照先がSQL APIの場合、NyanQLはそのSQLを実行し、次のような形に包んで配信します。
+
+```json
+{
+  "success": true,
+  "status": 200,
+  "result": [
+    { "id": 1, "name": "にゃんくる" }
+  ]
+}
+```
+
+`push` の参照先がscript APIの場合は、そのscriptが返した文字列をそのまま配信します。script側でJSON文字列を返すようにしておくと扱いやすくなります。
+
+### Pushでよくある勘違い
+
+`push` は、呼び出したAPI自身の結果をそのまま配信する機能ではありません。`push` に指定した別APIを実行し、その結果を指定チャネルへ配信する機能です。
+
+つまり、更新APIの後に一覧APIを配信する、という形が基本です。
+
+---
+
+## WebSocketクライアント機能
+
+NyanQLは、WebSocketサーバとしてPushを配信するだけでなく、NyanQL自身がWebSocketクライアントとして外部のWebSocketサーバへ接続することもできます。
+
+`api.json` で `type: "ws_client"` を指定します。
+
+```json
+{
+  "receiveExternalMessage": {
+    "type": "ws_client",
+    "script": "./javascript/ws/receiver.js",
+    "connectURL": "ws://localhost:8890/hello",
+    "description": "外部WebSocketからメッセージを受信します"
+  }
+}
+```
+
+この設定を書くと、NyanQLは起動時に `connectURL` へ接続します。接続が切れた場合は、時間をあけながら再接続を試みます。
+
+受信したメッセージは、`script` に渡されます。scriptの中では、次の値を `nyanAllParams` から参照できます。
+
+| 名前 | 内容 |
+|---|---|
+| `nyanAllParams.ws_client` | `api.json` 上のWebSocketクライアント名です。 |
+| `nyanAllParams.ws_message_type` | `text`、`binary` などのメッセージ種別です。 |
+| `nyanAllParams.ws_message_text` | 受信したメッセージの文字列です。 |
+| `nyanAllParams.ws_message_json` | テキストメッセージがJSONとして読めた場合の値です。 |
+| `nyanAllParams.ws_message_base64` | バイナリメッセージをBase64にした値です。 |
+| `nyanAllParams.ws_connect_url` | 接続先URLです。 |
+| `nyanAllParams.ws_description` | `api.json` に書いた説明です。 |
+
+scriptが空文字を返した場合、接続先へ返信しません。空でない文字列を返した場合、その文字列をWebSocketのテキストメッセージとして接続先へ送信します。
+
+`connectURL` には、環境変数を使うこともできます。
+
+```json
+{
+  "receiveExternalMessage": {
+    "type": "ws_client",
+    "script": "./javascript/ws/receiver.js",
+    "connectURL": "env:NYANQL_WS_URL",
+    "description": "環境変数で接続先を指定します"
+  }
+}
+```
+
+この場合、起動時に `NYANQL_WS_URL` の値を接続先として使います。
+
+---
+
+## JSON-RPC
+
+NyanQLは、通常のHTTP APIに加えて、JSON-RPC 2.0形式でも呼び出せます。
+
+エンドポイントは次のとおりです。
+
+```text
+/nyan-rpc
+```
+
+呼び出し例です。
+
+```bash
+curl -u admin:secret \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "getItem",
+    "params": { "id": 1 },
+    "id": 1
+  }' \
+  "http://localhost:8080/nyan-rpc"
+```
+
+`method` が、`api.json` のAPI名として扱われます。
+
+現在の実装では、JSON-RPCの一括リクエスト、つまりbatch形式には対応していません。
+
+---
+
+## セキュリティ上の注意
+
+NyanQLは、SQLやJavaScriptを使って強力なAPIを手軽に作れます。そのぶん、設定や公開範囲には注意が必要です。
+
+- Basic認証のユーザ名とパスワードは、公開環境では必ず変更してください。
+- `nyanHostExec` はOSコマンドを実行できるため、外部入力をそのまま渡さないでください。
+- CORSは現在 `*` を許可する実装です。公開環境で使う場合は、必要に応じて実装や配置で制御してください。
+- HTTPSを使う場合は、`CertPath` と `KeyPath` を指定してください。
+- SQLファイルやscriptファイルは、信頼できる人だけが編集できる場所に置いてください。
 
 ---
 
 ## 予約語
 
-`api`、`nyan` から始まる名前は予約語です。パラメータに使用しないでください。
+リクエストパラメータ名として、次の名前は避けてください。
+
+- `api`
+- `nyan` で始まる名前
+
+`api` は、呼び出すAPI名を指定するために使います。`nyanAllParams` や `nyan_mode` など、`nyan` で始まる名前はNyanQL側の制御用として使われます。
+
+---
+
+## 関連プロジェクト
+
+NyanQLは、Nyanシリーズの1つです。
+
+- NyanQL（にゃんくる）：SQLを中心に、データベースアクセスAPIを作る軽量フレームワーク
+- Nyan8（にゃんぱち）：JavaScriptでAPI処理を書くためのサーバ
+- NyanPUI（にゃんぷい）：HTMLや画面まわりを扱うための仕組み
+
+NyanQLは、DBアクセスに集中します。画面や複雑なアプリケーション構成が必要な場合は、NyanPUIやNyan8と組み合わせると使いやすくなります。
+
+---
+
+## 開発状況
+
+NyanQLは開発中のソフトウェアです。ただし、SQL実行、2way-SQL、JavaScriptによる処理、トランザクション、WebSocket Pushなど、主要な機能は実装されています。
+
+仕様や設定項目は、今後変わる可能性があります。利用時は、このREADMEと実際の `api.json`、`config.json`、サンプルSQLをあわせて確認してください。
+
+---
+
+## ライセンス
+
+NyanQLはMITライセンスで公開されています。
+

--- a/README.md
+++ b/README.md
@@ -762,6 +762,73 @@ scriptが空文字を返した場合、接続先へ返信しません。空で�
 
 ---
 
+## 定期実行ジョブ
+
+`api.json` で `type: "schedule"` を指定すると、NyanQLの起動時に定期実行ジョブとして登録されます。
+
+```json
+{
+  "dailyJob": {
+    "type": "schedule",
+    "script": "./javascript/daily_job.js",
+    "trigger": {
+      "type": "cron",
+      "value": "0 10 * * *"
+    },
+    "description": "毎日10:00に実行します"
+  }
+}
+```
+
+この例では、毎日10:00に `./javascript/daily_job.js` が実行されます。`type: "schedule"` の定義はHTTP APIとしては公開されないため、外部リクエストから直接実行されません。
+
+cronは5フィールド形式です。
+
+```text
+分 時 日 月 曜日
+```
+
+たとえば、次のように指定できます。
+
+| cron | 実行タイミング |
+|---|---|
+| `* * * * *` | 1分ごと |
+| `*/10 * * * *` | 10分ごと |
+| `0 10 * * *` | 毎日10:00 |
+| `15,45 * * * *` | 毎時15分と45分 |
+| `0 9-18 * * *` | 9時から18時まで毎時0分 |
+
+現在の実装では秒単位の指定には対応していません。最短の実行間隔は1分です。`*/10` は「起動してから10分ごと」ではなく、crontabと同じく時計の分が `00, 10, 20, 30, 40, 50` のタイミングで実行されます。
+
+scheduleのscript内では、通常のscriptと同じように `nyanAllParams` や `nyanRunSQL()` などを使えます。加えて、次の値が `nyanAllParams` に入ります。
+
+| 名前 | 内容 |
+|---|---|
+| `nyanAllParams.nyan_job_name` | `api.json` 上のジョブ名です。 |
+| `nyanAllParams.nyan_schedule_trigger_type` | 現在は `cron` です。 |
+| `nyanAllParams.nyan_schedule_trigger` | cron式です。 |
+| `nyanAllParams.nyan_schedule_time` | 実行予定時刻です。 |
+
+動作確認用のscript例です。
+
+```js
+const now = new Date();
+
+console.log(
+  "[schedule_debug]",
+  "executed_at=" + now.toISOString(),
+  "job=" + nyanAllParams.nyan_job_name,
+  "scheduled_at=" + nyanAllParams.nyan_schedule_time,
+  "trigger=" + nyanAllParams.nyan_schedule_trigger
+);
+
+"schedule_debug executed at " + now.toISOString();
+```
+
+`javascript_include` に設定した共通JavaScriptは、scheduleのscript実行時にも毎回読み込まれます。
+
+---
+
 ## JSON-RPC
 
 NyanQLは、通常のHTTP APIに加えて、JSON-RPC 2.0形式でも呼び出せます。

--- a/README.md
+++ b/README.md
@@ -208,26 +208,26 @@ SQLiteとDuckDBでは、`DBName` に相対パスを書いた場合、実行フ�
 
 この例では、`/listItems` または `/?api=listItems` を呼び出すと、`./sql/listItems.sql` が実行されます。
 
-### checkで入力を確認してからSQLを実行するAPI
+### paramCheckで入力を確認してからSQLを実行するAPI
 
 ```json
 {
   "getItem": {
-    "check": "./javascript/checkGetItem.js",
+    "paramCheck": "./javascript/checkGetItem.js",
     "sql": ["./sql/getItem.sql"],
     "description": "商品を1件取得します"
   }
 }
 ```
 
-`check` に指定したJavaScriptが先に実行されます。ここでエラーを返すと、SQLは実行されません。
+`paramCheck` に指定したJavaScriptが先に実行されます。ここでエラーを返すと、SQLは実行されません。古い `check` キーも互換性のため読み込めます。
 
 ### scriptを実行するAPI
 
 ```json
 {
   "createOrder": {
-    "check": "./javascript/checkCreateOrder.js",
+    "paramCheck": "./javascript/checkCreateOrder.js",
     "script": "./javascript/createOrder.js",
     "description": "注文伝票を1件登録します"
   }
@@ -235,6 +235,29 @@ SQLiteとDuckDBでは、`DBName` に相対パスを書いた場合、実行フ�
 ```
 
 `script` を指定したAPIでは、JavaScriptファイルを実行します。この場合、同じAPI定義の中に `sql` は書けません。実装上、`script` と `sql` を同時に指定すると起動時にエラーになります。
+
+### publicフォルダを公開するAPI
+
+`type: "public"` を指定すると、`path` のフォルダ配下にあるファイルをそのまま配信します。`path` は実行ファイルがある場所からの相対パス、または絶対パスで指定できます。
+
+```json
+{
+  "public": {
+    "type": "public",
+    "path": "./public",
+    "description": "publicフォルダ"
+  }
+}
+```
+
+この例では `./public/app.js` を `http://localhost:8080/public/app.js` で取得できます。空パス、存在しないファイル、ディレクトリへのアクセスは 404 になります。ディレクトリ一覧や `index.html` の自動探索は行いません。
+
+`type: "public"` はBasic認証を通さずに配信します。認証や認可が必要なファイル公開では、`paramCheck` を指定してください。`paramCheck` と `outCheck` では、公開エンドポイント名とリクエストされた相対パスを参照できます。
+
+```js
+var endpoint = nyanAllParams.nyan_public_endpoint;
+var path = nyanAllParams.nyan_public_path;
+```
 
 ---
 
@@ -454,9 +477,10 @@ const nyanOutputColumns = ["order_id", "order_no"];
 
 ---
 
-## 入力チェック：check
+## 入力チェック：paramCheck
 
-`check` は、SQLやscriptを実行する前に、リクエスト内容を確認するためのJavaScriptです。
+`paramCheck` は、SQLやscriptを実行する前に、リクエスト内容を確認するためのJavaScriptです。
+古い設定との互換性のため、`check` も `paramCheck` の別名として使えます。
 
 たとえば、`id` が指定されていない場合にエラーを返すには、次のように書きます。
 
@@ -478,17 +502,41 @@ if (!nyanAllParams.id) {
 }
 ```
 
-`check` の戻り値は、JSON文字列にしてください。NyanQLは、そのJSONを読んで、`success` が `true` なら次の処理へ進みます。`false` の場合は、SQLやscriptを実行せずにエラーを返します。
+`paramCheck` の戻り値は、JSON文字列またはオブジェクトにしてください。NyanQLは、そのJSONを読んで、`success` が `true` なら次の処理へ進みます。`false` の場合は、SQLやscriptを実行せずにエラーを返します。
 
 ### checkだけを実行する
 
-`nyan_mode=checkOnly` を指定すると、`check` だけを実行できます。
+`nyan_mode=checkOnly` を指定すると、`paramCheck` だけを実行できます。`check` で指定した古い設定も、`paramCheck` として同じように実行されます。
 
 ```bash
 curl -u admin:secret "http://localhost:8080/getItem?id=1&nyan_mode=checkOnly"
 ```
 
 入力フォームの事前チェックなどに使えます。
+
+### 出力前チェック：outCheck
+
+`outCheck` を指定すると、SQLやscriptの実行後、または `type: "public"` のファイル送信前にJavaScriptを実行できます。`success: true` かつ `status: 200` の場合だけ本体の実行結果をそのまま返し、それ以外は `outCheck` の結果をJSONとして返します。
+
+```json
+{
+  "checked-api": {
+    "script": "./javascript/main.js",
+    "outCheck": "./javascript/out_check.js",
+    "description": "出力前チェック付きAPI"
+  }
+}
+```
+
+本体の実行結果は `nyanAllParams.nyan_output` で参照できます。互換用に `nyan_output_body` なども使えます。
+
+```js
+if (nyanAllParams.nyan_output.body.indexOf("expected") >= 0) {
+  ({ success: true, status: 200, result: {} });
+} else {
+  ({ success: false, status: 409, result: { message: "output mismatch" } });
+}
+```
 
 ---
 
@@ -790,4 +838,3 @@ NyanQLは開発中のソフトウェアです。ただし、SQL実行、2way-SQL
 ## ライセンス
 
 NyanQLはMITライセンスで公開されています。
-

--- a/api.json
+++ b/api.json
@@ -17,19 +17,19 @@
     "description": "年と月を指定し、一覧を表示します。"
   },
   "check_day": {
-    "check": "./javascript/check.js",
+    "paramCheck": "./javascript/check.js",
     "sql": ["./sql/sqlite/check_day.sql"],
     "description": "日付で検索します"
   },
   "test1": {
-    "check": "./javascript/check.js",
+    "paramCheck": "./javascript/check.js",
     "push": "hello",
-    "description": "checkだけでsqlなしです。"
+    "description": "paramCheckだけでsqlなしです。"
   },
   "test2": {
-    "check": "./javascript/check_test1.js",
+    "paramCheck": "./javascript/check_test1.js",
     "script": "./javascript/script.js",
-    "description": "checkが実行されscriptが動くサンプルです。"
+    "description": "paramCheckが実行されscriptが動くサンプルです。"
   },
   "ids": {
     "sql": ["./sql/sqlite/get_by_ids.sql"],
@@ -54,7 +54,7 @@
   "websocket_clients_local": {
     "type": "ws_client",
     "script": "./javascript/ws/receiver_main.js",
-    "connectURL": "ws://localhost:8443/hello",
+    "connectURL": "ws://localhost:8443/hellogi",
     "description": "ローカル動作確認用（自身の /hello に接続）"
   }
 }

--- a/api.json
+++ b/api.json
@@ -51,6 +51,15 @@
     "script": "./javascript/nyan_callme_check.js",
     "description": "nyanCallMe の存在確認と内部API呼び出し結果を返します。"
   },
+  "schedule_debug_every_minute": {
+    "type": "schedule",
+    "script": "./javascript/schedule_debug.js",
+    "trigger": {
+      "type": "cron",
+      "value": "*/10 * * * *"
+    },
+    "description": "schedule の動作確認用。1分ごとにログへ実行時刻を出力します。"
+  },
   "websocket_clients_local": {
     "type": "ws_client",
     "script": "./javascript/ws/receiver_main.js",

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module NyanQL
 
-go 1.24
-
-toolchain go1.24.0
+go 1.26.3
 
 require (
 	github.com/dop251/goja v0.0.0-20250125213203-5ef83b82af17

--- a/javascript/schedule_debug.js
+++ b/javascript/schedule_debug.js
@@ -1,0 +1,11 @@
+const now = new Date();
+
+console.log(
+  "[schedule_debug]",
+  "executed_at=" + now.toISOString(),
+  "job=" + nyanAllParams.nyan_job_name,
+  "scheduled_at=" + nyanAllParams.nyan_schedule_time,
+  "trigger=" + nyanAllParams.nyan_schedule_trigger
+);
+
+"schedule_debug executed at " + now.toISOString();

--- a/main.go
+++ b/main.go
@@ -71,11 +71,58 @@ type LogConfig struct {
 type APIConfig struct {
 	SQL         []string `json:"sql,omitempty"`
 	Script      string   `json:"script,omitempty"`
-	Check       string   `json:"check,omitempty"`
+	Path        string   `json:"path,omitempty"`
+	ParamCheck  string   `json:"paramCheck,omitempty"`
+	Check       string   `json:"check,omitempty"` // Deprecated: use ParamCheck. Kept as a compatibility alias.
+	OutCheck    string   `json:"outCheck,omitempty"`
 	Push        string   `json:"push,omitempty"`
 	Description string   `json:"description"`
 	Type        string   `json:"type,omitempty"`
 	ConnectURL  string   `json:"connectURL,omitempty"`
+}
+
+func (apiConfig *APIConfig) UnmarshalJSON(data []byte) error {
+	type apiConfigJSON struct {
+		SQL             []string `json:"sql,omitempty"`
+		Script          string   `json:"script,omitempty"`
+		Path            string   `json:"path,omitempty"`
+		ParamCheck      string   `json:"paramCheck,omitempty"`
+		ParamCheckLower string   `json:"paramcheck,omitempty"`
+		Check           string   `json:"check,omitempty"`
+		OutCheck        string   `json:"outCheck,omitempty"`
+		OutCheckLower   string   `json:"outcheck,omitempty"`
+		Push            string   `json:"push,omitempty"`
+		Description     string   `json:"description"`
+		Type            string   `json:"type,omitempty"`
+		ConnectURL      string   `json:"connectURL,omitempty"`
+	}
+
+	var raw apiConfigJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	apiConfig.SQL = raw.SQL
+	apiConfig.Script = raw.Script
+	apiConfig.Path = raw.Path
+	apiConfig.ParamCheck = raw.ParamCheck
+	if apiConfig.ParamCheck == "" {
+		apiConfig.ParamCheck = raw.ParamCheckLower
+	}
+	if apiConfig.ParamCheck == "" {
+		apiConfig.ParamCheck = raw.Check
+	}
+	apiConfig.Check = ""
+	apiConfig.OutCheck = raw.OutCheck
+	if apiConfig.OutCheck == "" {
+		apiConfig.OutCheck = raw.OutCheckLower
+	}
+	apiConfig.Push = raw.Push
+	apiConfig.Description = raw.Description
+	apiConfig.Type = raw.Type
+	apiConfig.ConnectURL = raw.ConnectURL
+
+	return nil
 }
 
 type Hub struct {
@@ -148,6 +195,7 @@ var buildVersion = "v0.0.18"
 const (
 	apiTypeAPI      = "api"
 	apiTypeWSClient = "ws_client"
+	apiTypePublic   = "public"
 )
 
 // reParams は、/*id*/ のようなプレースホルダーを抽出する正規表現
@@ -254,8 +302,42 @@ func unifiedHandler(w http.ResponseWriter, r *http.Request) {
 		handleWebSocket(w, r)
 		return
 	}
+	if apiKey, requestedPath, apiConfig, ok := findPublicAPIForPath(r.URL.Path); ok {
+		handlePublicRequest(w, r, apiKey, requestedPath, apiConfig)
+		return
+	}
 	// 通常のHTTPリクエストならBasicAuthを適用して処理
 	basicAuth(handleRequest, config)(w, r)
+}
+
+func findPublicAPIForPath(requestPath string) (string, string, APIConfig, bool) {
+	var matchedKey string
+	var matchedPath string
+	var matchedConfig APIConfig
+	for apiKey, apiConfig := range sqlFiles {
+		if getAPIType(apiConfig) != apiTypePublic {
+			continue
+		}
+		routePath := "/" + strings.Trim(strings.TrimSpace(apiKey), "/")
+		if routePath == "/" {
+			continue
+		}
+		if requestPath == routePath || strings.HasPrefix(requestPath, routePath+"/") {
+			if len(routePath) <= len(matchedPath) {
+				continue
+			}
+			matchedKey = apiKey
+			matchedPath = routePath
+			matchedConfig = apiConfig
+		}
+	}
+	if matchedKey == "" {
+		return "", "", APIConfig{}, false
+	}
+	if requestPath == matchedPath {
+		return matchedKey, "", matchedConfig, true
+	}
+	return matchedKey, strings.TrimPrefix(requestPath, matchedPath+"/"), matchedConfig, true
 }
 
 // WebSocketリクエストかどうかを判定する関数例
@@ -314,6 +396,10 @@ func loadSQLFiles(execDir string) {
 				sqlFiles[apiKey].SQL[i] = filepath.Join(execDir, sqlPath)
 			}
 		}
+		if apiConfig.Path != "" && !filepath.IsAbs(apiConfig.Path) {
+			apiConfig.Path = filepath.Join(execDir, apiConfig.Path)
+			sqlFiles[apiKey] = apiConfig
+		}
 	}
 }
 
@@ -323,6 +409,201 @@ func getAPIType(apiConfig APIConfig) string {
 		return apiTypeAPI
 	}
 	return t
+}
+
+func getParamCheckScriptPath(apiConfig APIConfig) string {
+	if apiConfig.ParamCheck != "" {
+		return apiConfig.ParamCheck
+	}
+	return apiConfig.Check
+}
+
+func cloneParams(params map[string]interface{}) map[string]interface{} {
+	cloned := make(map[string]interface{}, len(params))
+	for key, value := range params {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func runOutCheckScript(apiConfig APIConfig, params map[string]interface{}, statusCode int, contentType string, body []byte) (bool, int, string, error) {
+	outCheckPath := strings.TrimSpace(apiConfig.OutCheck)
+	if outCheckPath == "" {
+		return false, statusCode, "", nil
+	}
+
+	checkParams := cloneParams(params)
+	bodyString := string(body)
+	bodyBase64 := base64.StdEncoding.EncodeToString(body)
+	checkParams["nyan_output"] = map[string]interface{}{
+		"status":          statusCode,
+		"contentType":     contentType,
+		"headers":         map[string]string{},
+		"body":            bodyString,
+		"bodyBase64":      bodyBase64,
+		"bodyLength":      len(body),
+		"bodyLengthBytes": len(body),
+	}
+	checkParams["nyan_output_status"] = statusCode
+	checkParams["nyan_output_content_type"] = contentType
+	checkParams["nyan_output_body"] = bodyString
+	checkParams["nyan_output_body_base64"] = bodyBase64
+
+	success, checkStatusCode, _, jsonStr, err := runCheckScript(outCheckPath, checkParams, nil)
+	if err != nil {
+		return true, http.StatusInternalServerError, "", err
+	}
+	if checkStatusCode < 100 || checkStatusCode > 599 {
+		return true, http.StatusInternalServerError, "", fmt.Errorf("outCheck response status is out of range: %d", checkStatusCode)
+	}
+	if success && checkStatusCode == http.StatusOK {
+		return false, statusCode, "", nil
+	}
+	return true, checkStatusCode, jsonStr, nil
+}
+
+func isCheckOnlyMode(params map[string]interface{}) bool {
+	if params == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(fmt.Sprint(params["nyan_mode"])), "checkOnly")
+}
+
+func collectRequestParams(r *http.Request) (map[string]interface{}, error) {
+	contentType := r.Header.Get("Content-Type")
+	if strings.HasPrefix(contentType, "application/json") {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error reading request body: %v", err)
+		}
+		var data map[string]interface{}
+		if len(strings.TrimSpace(string(body))) == 0 {
+			data = map[string]interface{}{}
+		} else if err := json.Unmarshal(body, &data); err != nil {
+			return nil, fmt.Errorf("error parsing JSON data: %v", err)
+		}
+		log.Printf("Received JSON: %v", data)
+		return data, nil
+	}
+
+	if err := r.ParseForm(); err != nil {
+		return nil, fmt.Errorf("error parsing form data: %v", err)
+	}
+	params := make(map[string]interface{})
+	for key, values := range r.Form {
+		if len(values) > 1 {
+			params[key] = values
+			continue
+		}
+		val := values[0]
+		if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
+			var arr []interface{}
+			if err := json.Unmarshal([]byte(val), &arr); err == nil {
+				params[key] = arr
+				continue
+			}
+		}
+		if strings.Contains(val, ",") {
+			splitVals := strings.Split(val, ",")
+			for i := range splitVals {
+				splitVals[i] = strings.TrimSpace(splitVals[i])
+			}
+			params[key] = splitVals
+		} else {
+			params[key] = val
+		}
+	}
+	return params, nil
+}
+
+func handlePublicRequest(w http.ResponseWriter, r *http.Request, apiKey string, requestedPath string, apiConfig APIConfig) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	publicPath := strings.TrimSpace(apiConfig.Path)
+	if publicPath == "" {
+		sendJSONError(w, "public path is missing", http.StatusInternalServerError)
+		return
+	}
+
+	params, err := collectRequestParams(r)
+	if err != nil {
+		sendJSONError(w, "Invalid JSON data", http.StatusBadRequest)
+		return
+	}
+	params["api"] = apiKey
+	params["nyan_public_endpoint"] = apiKey
+	params["nyan_public_path"] = requestedPath
+
+	checkScriptPath := getParamCheckScriptPath(apiConfig)
+	if checkScriptPath == "" && isCheckOnlyMode(params) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"success":true,"status":200,"result":null}`))
+		return
+	}
+	if checkScriptPath != "" {
+		success, statusCode, errorObj, jsonStr, err := runCheckScript(checkScriptPath, params, nil)
+		if err != nil {
+			log.Printf("Public paramCheck script error: %v", err)
+			sendJSONError(w, err.Error(), statusCode)
+			return
+		}
+		allowed := success && statusCode == http.StatusOK
+		if isCheckOnlyMode(params) || !allowed {
+			if !success && errorObj != nil {
+				log.Printf("Public paramCheck rejected %s/%s: %v", apiKey, requestedPath, errorObj)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(statusCode)
+			w.Write([]byte(jsonStr))
+			return
+		}
+	}
+
+	if requestedPath == "" || !filepath.IsLocal(requestedPath) {
+		http.NotFound(w, r)
+		return
+	}
+	filePath := filepath.Join(publicPath, requestedPath)
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			http.NotFound(w, r)
+			return
+		}
+		sendJSONError(w, "failed to read public file", http.StatusInternalServerError)
+		return
+	}
+	if fileInfo.IsDir() {
+		http.NotFound(w, r)
+		return
+	}
+
+	if strings.TrimSpace(apiConfig.OutCheck) == "" {
+		http.ServeFile(w, r, filePath)
+		return
+	}
+	fileContent, err := os.ReadFile(filePath)
+	if err != nil {
+		sendJSONError(w, "failed to read public file", http.StatusInternalServerError)
+		return
+	}
+	contentType := http.DetectContentType(fileContent)
+	if handled, outStatusCode, outJSON, err := runOutCheckScript(apiConfig, params, http.StatusOK, contentType, fileContent); handled {
+		if err != nil {
+			log.Printf("Public outCheck script error: %v", err)
+			sendJSONError(w, err.Error(), outStatusCode)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(outStatusCode)
+		w.Write([]byte(outJSON))
+		return
+	}
+	http.ServeContent(w, r, fileInfo.Name(), fileInfo.ModTime(), bytes.NewReader(fileContent))
 }
 
 // connectURL が env:XXXX 形式なら環境変数 XXXX で解決する。空や未設定はエラー。
@@ -588,50 +869,10 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	contentType := r.Header.Get("Content-Type")
-	var params map[string]interface{}
-	if contentType == "application/json" {
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			sendJSONError(w, "Error reading request body", http.StatusInternalServerError)
-			return
-		}
-		var data map[string]interface{}
-		if err := json.Unmarshal(body, &data); err != nil {
-			sendJSONError(w, "Error parsing JSON data", http.StatusBadRequest)
-			return
-		}
-		log.Printf("Received JSON: %v", data)
-		params = data
-	} else {
-		if err := r.ParseForm(); err != nil {
-			sendJSONError(w, "Error parsing form data", http.StatusBadRequest)
-			return
-		}
-		params = make(map[string]interface{})
-		for key, values := range r.Form {
-			if len(values) > 1 {
-				params[key] = values
-			} else {
-				val := values[0]
-				if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
-					var arr []interface{}
-					if err := json.Unmarshal([]byte(val), &arr); err == nil {
-						params[key] = arr
-						continue
-					}
-				}
-				if strings.Contains(val, ",") {
-					splitVals := strings.Split(val, ",")
-					for i := range splitVals {
-						splitVals[i] = strings.TrimSpace(splitVals[i])
-					}
-					params[key] = splitVals
-				} else {
-					params[key] = val
-				}
-			}
-		}
+	params, err := collectRequestParams(r)
+	if err != nil {
+		sendJSONError(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 	if r.URL.Path != "/" {
 		apiName := strings.TrimPrefix(r.URL.Path, "/")
@@ -661,12 +902,13 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		acceptedKeys = []string{}
 	}
 	nyanMode, _ := params["nyan_mode"].(string)
-	if nyanMode == "checkOnly" && apiConfig.Check == "" {
+	checkScriptPath := getParamCheckScriptPath(apiConfig)
+	if nyanMode == "checkOnly" && checkScriptPath == "" {
 		sendJSONError(w, "No check script for this API", http.StatusNotFound)
 		return
 	}
-	if apiConfig.Check != "" {
-		success, statusCode, errorObj, jsonStr, err := runCheckScript(apiConfig.Check, params, acceptedKeys)
+	if checkScriptPath != "" {
+		success, statusCode, errorObj, jsonStr, err := runCheckScript(checkScriptPath, params, acceptedKeys)
 		if err != nil {
 			log.Printf("Check script error: %v", err)
 			sendJSONError(w, err.Error(), statusCode)
@@ -693,19 +935,6 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(jsonStr))
 			return
 		}
-		if apiConfig.Script != "" {
-			scriptResult, err := runScript([]string{apiConfig.Script}, params)
-			if err != nil {
-				log.Printf("Script execution error: %v", err)
-				sendJSONError(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-			performPush(apiConfig, params)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(scriptResult))
-			return
-		}
 		if len(apiConfig.SQL) == 0 && apiConfig.Script == "" {
 			performPush(apiConfig, params)
 			w.Header().Set("Content-Type", "application/json")
@@ -713,6 +942,32 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(jsonStr))
 			return
 		}
+	}
+
+	if apiConfig.Script != "" {
+		scriptResult, err := runScript([]string{apiConfig.Script}, params)
+		if err != nil {
+			log.Printf("Script execution error: %v", err)
+			sendJSONError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		body := []byte(scriptResult)
+		if handled, outStatusCode, outJSON, err := runOutCheckScript(apiConfig, params, http.StatusOK, "application/json", body); handled {
+			if err != nil {
+				log.Printf("outCheck script error: %v", err)
+				sendJSONError(w, err.Error(), outStatusCode)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(outStatusCode)
+			w.Write([]byte(outJSON))
+			return
+		}
+		performPush(apiConfig, params)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(body)
+		return
 	}
 
 	var tx *sql.Tx
@@ -798,9 +1053,6 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		lastJSON = []byte("[]")
 	}
 
-	// push 処理
-	performPush(apiConfig, params)
-
 	// SQL実行結果を固定順序の構造体で返す
 	type SQLResponse struct {
 		Success bool            `json:"success"`
@@ -812,10 +1064,26 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		Status:  200,
 		Result:  lastJSON,
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		log.Printf("Failed to encode JSON: %v", err)
+	body, err := json.Marshal(response)
+	if err != nil {
+		log.Printf("Failed to marshal JSON: %v", err)
+		sendJSONError(w, "Error formatting results", http.StatusInternalServerError)
+		return
 	}
+	if handled, outStatusCode, outJSON, err := runOutCheckScript(apiConfig, params, http.StatusOK, "application/json", body); handled {
+		if err != nil {
+			log.Printf("outCheck script error: %v", err)
+			sendJSONError(w, err.Error(), outStatusCode)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(outStatusCode)
+		w.Write([]byte(outJSON))
+		return
+	}
+	performPush(apiConfig, params)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(body)
 }
 
 func isSelectQuery(query string) bool {
@@ -1399,7 +1667,10 @@ func runCheckScript(apiCheckScriptPath string, params map[string]interface{}, ac
 	if err != nil {
 		return false, 500, nil, "", fmt.Errorf("check script error: %v", err)
 	}
-	jsonStr := value.String()
+	jsonStr, err := checkResultToJSONString(value)
+	if err != nil {
+		return false, 500, nil, "", err
+	}
 	var result struct {
 		Success bool        `json:"success"`
 		Status  int         `json:"status"`
@@ -1409,6 +1680,21 @@ func runCheckScript(apiCheckScriptPath string, params map[string]interface{}, ac
 		return false, 500, nil, jsonStr, fmt.Errorf("failed to unmarshal check result: %v", err)
 	}
 	return result.Success, result.Status, result.Error, jsonStr, nil
+}
+
+func checkResultToJSONString(value goja.Value) (string, error) {
+	if value == nil || goja.IsUndefined(value) || goja.IsNull(value) {
+		return "", fmt.Errorf("check script must return JSON")
+	}
+	exported := value.Export()
+	if jsonStr, ok := exported.(string); ok {
+		return jsonStr, nil
+	}
+	b, err := json.Marshal(exported)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal check result: %v", err)
+	}
+	return string(b), nil
 }
 
 func getAPI(url, username, password string) (string, error) {
@@ -1574,12 +1860,13 @@ func callNyanAPIFromVM(apiName string, allParams map[string]interface{}) (string
 		acceptedKeys = []string{}
 	}
 	nyanMode, _ := params["nyan_mode"].(string)
-	if nyanMode == "checkOnly" && apiConfig.Check == "" {
+	checkScriptPath := getParamCheckScriptPath(apiConfig)
+	if nyanMode == "checkOnly" && checkScriptPath == "" {
 		return "", fmt.Errorf("No check script for API %s", apiName)
 	}
 
-	if apiConfig.Check != "" {
-		success, statusCode, errorObj, jsonStr, err := runCheckScript(apiConfig.Check, params, acceptedKeys)
+	if checkScriptPath != "" {
+		success, statusCode, errorObj, jsonStr, err := runCheckScript(checkScriptPath, params, acceptedKeys)
 		if err != nil {
 			return "", fmt.Errorf("check script error: %v", err)
 		}
@@ -1607,6 +1894,12 @@ func callNyanAPIFromVM(apiName string, allParams map[string]interface{}) (string
 			if err != nil {
 				return "", fmt.Errorf("failed to run API %s: %v", apiName, err)
 			}
+			if handled, _, outJSON, err := runOutCheckScript(apiConfig, params, http.StatusOK, "application/json", []byte(result)); handled {
+				if err != nil {
+					return "", fmt.Errorf("outCheck script error: %v", err)
+				}
+				return outJSON, nil
+			}
 			performPush(apiConfig, params)
 			return result, nil
 		}
@@ -1620,6 +1913,12 @@ func callNyanAPIFromVM(apiName string, allParams map[string]interface{}) (string
 		result, err := runScript([]string{apiConfig.Script}, params)
 		if err != nil {
 			return "", fmt.Errorf("failed to run API %s: %v", apiName, err)
+		}
+		if handled, _, outJSON, err := runOutCheckScript(apiConfig, params, http.StatusOK, "application/json", []byte(result)); handled {
+			if err != nil {
+				return "", fmt.Errorf("outCheck script error: %v", err)
+			}
+			return outJSON, nil
 		}
 		performPush(apiConfig, params)
 		return result, nil
@@ -1696,8 +1995,6 @@ func callNyanAPIFromVM(apiName string, allParams map[string]interface{}) (string
 		lastJSON = []byte("[]")
 	}
 
-	performPush(apiConfig, params)
-
 	response := SQLResponse{
 		Success: true,
 		Status:  200,
@@ -1707,6 +2004,13 @@ func callNyanAPIFromVM(apiName string, allParams map[string]interface{}) (string
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal SQL response for API %s: %v", apiName, err)
 	}
+	if handled, _, outJSON, err := runOutCheckScript(apiConfig, params, http.StatusOK, "application/json", b); handled {
+		if err != nil {
+			return "", fmt.Errorf("outCheck script error: %v", err)
+		}
+		return outJSON, nil
+	}
+	performPush(apiConfig, params)
 	return string(b), nil
 }
 
@@ -2064,6 +2368,24 @@ func respondJSONRPCError(w http.ResponseWriter, id interface{}, code int, messag
 	json.NewEncoder(w).Encode(resp)
 }
 
+func respondJSONRPCResultJSON(w http.ResponseWriter, id interface{}, statusCode int, jsonStr string) {
+	var result interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
+		respondJSONRPCError(w, id, -32603, "Failed to parse check result", err.Error())
+		return
+	}
+	rpcResp := JSONRPCResponse{
+		JSONRPC: "2.0",
+		Result:  result,
+		ID:      id,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	if err := json.NewEncoder(w).Encode(rpcResp); err != nil {
+		log.Printf("Failed to encode JSON-RPC response: %v", err)
+	}
+}
+
 func handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 	// 1) リクエストボディを読み込み、JSONRPCRequestにパースする
 	body, err := ioutil.ReadAll(r.Body)
@@ -2122,8 +2444,9 @@ func handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Failed to get accepted params keys: %v", err)
 		acceptedKeys = []string{}
 	}
-	if apiConfig.Check != "" {
-		success, statusCode, errorObj, jsonStr, err := runCheckScript(apiConfig.Check, allParams, acceptedKeys)
+	checkScriptPath := getParamCheckScriptPath(apiConfig)
+	if checkScriptPath != "" {
+		success, statusCode, errorObj, jsonStr, err := runCheckScript(checkScriptPath, allParams, acceptedKeys)
 		if err != nil {
 			respondJSONRPCError(w, rpcReq.ID, -32603, "Check script error", err.Error())
 			return
@@ -2158,6 +2481,7 @@ func handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 
 	// 5) メインの処理: Script または SQL の実行
 	var finalResult map[string]interface{}
+	var finalBody []byte
 	if apiConfig.Script != "" {
 		scriptResult, err := runScript([]string{apiConfig.Script}, allParams)
 		if err != nil {
@@ -2168,6 +2492,7 @@ func handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 			respondJSONRPCError(w, rpcReq.ID, -32603, "Failed to parse script result as JSON", err.Error())
 			return
 		}
+		finalBody = []byte(scriptResult)
 	} else if len(apiConfig.SQL) > 0 {
 		var tx *sql.Tx
 		if len(apiConfig.SQL) > 1 {
@@ -2239,8 +2564,28 @@ func handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 			"status":  200,
 			"result":  json.RawMessage(lastJSON),
 		}
+		finalBody, err = json.Marshal(finalResult)
+		if err != nil {
+			respondJSONRPCError(w, rpcReq.ID, -32603, "Failed to marshal SQL result", err.Error())
+			return
+		}
 	} else {
 		respondJSONRPCError(w, rpcReq.ID, -32603, "No script or SQL defined for this method", nil)
+		return
+	}
+
+	statusCode := 200
+	if st, ok := finalResult["status"].(float64); ok {
+		statusCode = int(st)
+	} else if st, ok := finalResult["status"].(int); ok {
+		statusCode = st
+	}
+	if handled, outStatusCode, outJSON, err := runOutCheckScript(apiConfig, allParams, statusCode, "application/json", finalBody); handled {
+		if err != nil {
+			respondJSONRPCError(w, rpcReq.ID, -32603, "outCheck script error", err.Error())
+			return
+		}
+		respondJSONRPCResultJSON(w, rpcReq.ID, outStatusCode, outJSON)
 		return
 	}
 
@@ -2248,9 +2593,10 @@ func handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 	performPush(apiConfig, allParams)
 
 	// 7) 最終レスポンスの返却
-	statusCode := 200
 	if st, ok := finalResult["status"].(float64); ok {
 		statusCode = int(st)
+		delete(finalResult, "status")
+	} else if _, ok := finalResult["status"].(int); ok {
 		delete(finalResult, "status")
 	}
 	rpcResp := JSONRPCResponse{

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -229,6 +229,7 @@ func main() {
 	adjustPaths(execDir, &config)
 	setupLogger(execDir)
 	log.Printf("Binary version: %s", buildVersion)
+	log.Printf("Go runtime version: %s", runtime.Version())
 	log.Printf("Config version: %s", config.Version)
 
 	db, err = connectDB(config)
@@ -377,7 +378,7 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 func loadSQLFiles(execDir string) {
 	apiFilePath := filepath.Join(execDir, "api.json")
-	data, err := ioutil.ReadFile(apiFilePath)
+	data, err := os.ReadFile(apiFilePath)
 	if err != nil {
 		log.Fatalf("Failed to read SQL files config: %v", err)
 	}
@@ -472,7 +473,7 @@ func isCheckOnlyMode(params map[string]interface{}) bool {
 func collectRequestParams(r *http.Request) (map[string]interface{}, error) {
 	contentType := r.Header.Get("Content-Type")
 	if strings.HasPrefix(contentType, "application/json") {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return nil, fmt.Errorf("error reading request body: %v", err)
 		}
@@ -984,7 +985,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	var lastJSON []byte
 	for _, sqlPath := range apiConfig.SQL {
-		query, err := ioutil.ReadFile(sqlPath)
+		query, err := os.ReadFile(sqlPath)
 		if err != nil {
 			log.Printf("Failed to read SQL file: %v", err)
 			sendJSONError(w, "Error reading SQL file", http.StatusInternalServerError)
@@ -1377,7 +1378,7 @@ func handleNyanDetail(w http.ResponseWriter, r *http.Request) {
 func parseSQLParams(filePaths []string) (map[string]interface{}, error) {
 	result := make(map[string]interface{})
 	for _, filePath := range filePaths {
-		data, err := ioutil.ReadFile(filePath)
+		data, err := os.ReadFile(filePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file %s: %v", filePath, err)
 		}
@@ -1573,7 +1574,7 @@ func nyanRunSQLHandler(vm *goja.Runtime, call goja.FunctionCall) goja.Value {
 	}
 
 	// SQLファイルの読み込み
-	sqlContent, err := ioutil.ReadFile(sqlFilePath)
+	sqlContent, err := os.ReadFile(sqlFilePath)
 	if err != nil {
 		panic(vm.ToValue(fmt.Sprintf("failed to read SQL file %s: %v", sqlFilePath, err)))
 	}
@@ -1646,14 +1647,14 @@ func nyanRunSQLHandler(vm *goja.Runtime, call goja.FunctionCall) goja.Value {
 func runCheckScript(apiCheckScriptPath string, params map[string]interface{}, acceptedParamsKeys []string) (bool, int, interface{}, string, error) {
 	var combinedScript strings.Builder
 	for _, includePath := range config.JavascriptInclude {
-		content, err := ioutil.ReadFile(includePath)
+		content, err := os.ReadFile(includePath)
 		if err != nil {
 			return false, 500, nil, "", fmt.Errorf("failed to read javascript include file %s: %v", includePath, err)
 		}
 		combinedScript.Write(content)
 		combinedScript.WriteString("\n")
 	}
-	checkContent, err := ioutil.ReadFile(apiCheckScriptPath)
+	checkContent, err := os.ReadFile(apiCheckScriptPath)
 	if err != nil {
 		return false, 500, nil, "", fmt.Errorf("failed to read check script %s: %v", apiCheckScriptPath, err)
 	}
@@ -1711,7 +1712,7 @@ func getAPI(url, username, password string) (string, error) {
 		return "", fmt.Errorf("error sending request: %v", err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("error reading response: %v", err)
 	}
@@ -1748,7 +1749,7 @@ func jsonAPI(url string, jsonData []byte, username, password string, headers map
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -1792,7 +1793,7 @@ func runScript(scriptPaths []string, params map[string]interface{}) (string, err
 	var combinedScript strings.Builder
 
 	for _, includePath := range config.JavascriptInclude {
-		content, err := ioutil.ReadFile(includePath)
+		content, err := os.ReadFile(includePath)
 		if err != nil {
 			return "", fmt.Errorf("failed to read javascript include file %s: %v", includePath, err)
 		}
@@ -1800,7 +1801,7 @@ func runScript(scriptPaths []string, params map[string]interface{}) (string, err
 		combinedScript.WriteString("\n")
 	}
 	for _, scriptPath := range scriptPaths {
-		content, err := ioutil.ReadFile(scriptPath)
+		content, err := os.ReadFile(scriptPath)
 		if err != nil {
 			return "", fmt.Errorf("failed to read script file %s: %v", scriptPath, err)
 		}
@@ -1939,7 +1940,7 @@ func callNyanAPIFromVM(apiName string, allParams map[string]interface{}) (string
 
 	var lastJSON []byte
 	for _, sqlPath := range apiConfig.SQL {
-		query, err := ioutil.ReadFile(sqlPath)
+		query, err := os.ReadFile(sqlPath)
 		if err != nil {
 			return "", fmt.Errorf("failed to read SQL file for API %s: %v", apiName, err)
 		}
@@ -2149,7 +2150,7 @@ func normalizeSQL(sqlText string) string {
 func executeAPIConfig(apiConfig APIConfig) ([]byte, error) {
 	// ここでは、SQLが設定されている場合、最初のSQLファイルを実行する例です
 	if len(apiConfig.SQL) > 0 {
-		query, err := ioutil.ReadFile(apiConfig.SQL[0])
+		query, err := os.ReadFile(apiConfig.SQL[0])
 		if err != nil {
 			return nil, fmt.Errorf("failed to read SQL file: %v", err)
 		}
@@ -2304,7 +2305,7 @@ func nyanGetFile(vm *goja.Runtime) func(call goja.FunctionCall) goja.Value {
 
 // parseScriptConstants は、指定されたスクリプトファイルから定数をパースします。
 func parseScriptConstants(scriptPath string) (map[string]interface{}, []string, error) {
-	data, err := ioutil.ReadFile(scriptPath)
+	data, err := os.ReadFile(scriptPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read script file %s: %v", scriptPath, err)
 	}
@@ -2388,7 +2389,7 @@ func respondJSONRPCResultJSON(w http.ResponseWriter, id interface{}, statusCode 
 
 func handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 	// 1) リクエストボディを読み込み、JSONRPCRequestにパースする
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		respondJSONRPCError(w, nil, -32700, "Parse error (failed to read body)", err.Error())
 		return
@@ -2505,7 +2506,7 @@ func handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 		}
 		var lastJSON []byte
 		for _, sqlPath := range apiConfig.SQL {
-			query, err := ioutil.ReadFile(sqlPath)
+			query, err := os.ReadFile(sqlPath)
 			if err != nil {
 				respondJSONRPCError(w, rpcReq.ID, -32603, "Error reading SQL file", err.Error())
 				return

--- a/main.go
+++ b/main.go
@@ -69,32 +69,39 @@ type LogConfig struct {
 }
 
 type APIConfig struct {
-	SQL         []string `json:"sql,omitempty"`
-	Script      string   `json:"script,omitempty"`
-	Path        string   `json:"path,omitempty"`
-	ParamCheck  string   `json:"paramCheck,omitempty"`
-	Check       string   `json:"check,omitempty"` // Deprecated: use ParamCheck. Kept as a compatibility alias.
-	OutCheck    string   `json:"outCheck,omitempty"`
-	Push        string   `json:"push,omitempty"`
-	Description string   `json:"description"`
-	Type        string   `json:"type,omitempty"`
-	ConnectURL  string   `json:"connectURL,omitempty"`
+	SQL         []string      `json:"sql,omitempty"`
+	Script      string        `json:"script,omitempty"`
+	Path        string        `json:"path,omitempty"`
+	ParamCheck  string        `json:"paramCheck,omitempty"`
+	Check       string        `json:"check,omitempty"` // Deprecated: use ParamCheck. Kept as a compatibility alias.
+	OutCheck    string        `json:"outCheck,omitempty"`
+	Push        string        `json:"push,omitempty"`
+	Trigger     TriggerConfig `json:"trigger,omitempty"`
+	Description string        `json:"description"`
+	Type        string        `json:"type,omitempty"`
+	ConnectURL  string        `json:"connectURL,omitempty"`
+}
+
+type TriggerConfig struct {
+	Type  string `json:"type,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 func (apiConfig *APIConfig) UnmarshalJSON(data []byte) error {
 	type apiConfigJSON struct {
-		SQL             []string `json:"sql,omitempty"`
-		Script          string   `json:"script,omitempty"`
-		Path            string   `json:"path,omitempty"`
-		ParamCheck      string   `json:"paramCheck,omitempty"`
-		ParamCheckLower string   `json:"paramcheck,omitempty"`
-		Check           string   `json:"check,omitempty"`
-		OutCheck        string   `json:"outCheck,omitempty"`
-		OutCheckLower   string   `json:"outcheck,omitempty"`
-		Push            string   `json:"push,omitempty"`
-		Description     string   `json:"description"`
-		Type            string   `json:"type,omitempty"`
-		ConnectURL      string   `json:"connectURL,omitempty"`
+		SQL             []string      `json:"sql,omitempty"`
+		Script          string        `json:"script,omitempty"`
+		Path            string        `json:"path,omitempty"`
+		ParamCheck      string        `json:"paramCheck,omitempty"`
+		ParamCheckLower string        `json:"paramcheck,omitempty"`
+		Check           string        `json:"check,omitempty"`
+		OutCheck        string        `json:"outCheck,omitempty"`
+		OutCheckLower   string        `json:"outcheck,omitempty"`
+		Push            string        `json:"push,omitempty"`
+		Trigger         TriggerConfig `json:"trigger,omitempty"`
+		Description     string        `json:"description"`
+		Type            string        `json:"type,omitempty"`
+		ConnectURL      string        `json:"connectURL,omitempty"`
 	}
 
 	var raw apiConfigJSON
@@ -118,6 +125,7 @@ func (apiConfig *APIConfig) UnmarshalJSON(data []byte) error {
 		apiConfig.OutCheck = raw.OutCheckLower
 	}
 	apiConfig.Push = raw.Push
+	apiConfig.Trigger = raw.Trigger
 	apiConfig.Description = raw.Description
 	apiConfig.Type = raw.Type
 	apiConfig.ConnectURL = raw.ConnectURL
@@ -196,6 +204,7 @@ const (
 	apiTypeAPI      = "api"
 	apiTypeWSClient = "ws_client"
 	apiTypePublic   = "public"
+	apiTypeSchedule = "schedule"
 )
 
 // reParams は、/*id*/ のようなプレースホルダーを抽出する正規表現
@@ -239,6 +248,9 @@ func main() {
 	loadSQLFiles(execDir)
 	if err := startWebSocketClients(execDir); err != nil {
 		log.Printf("Failed to start WebSocket clients: %v", err)
+	}
+	if err := startScheduleJobs(execDir); err != nil {
+		log.Printf("Failed to start schedule jobs: %v", err)
 	}
 
 	corsHandler := cors.New(cors.Options{
@@ -632,6 +644,253 @@ type wsClientConfig struct {
 	scriptPath  string
 	connectURL  string
 	description string
+}
+
+type scheduleJobConfig struct {
+	name        string
+	scriptPath  string
+	trigger     TriggerConfig
+	description string
+	schedule    cronSchedule
+}
+
+type cronSchedule struct {
+	minutes     cronField
+	hours       cronField
+	days        cronField
+	months      cronField
+	weekdays    cronField
+	dayStar     bool
+	weekdayStar bool
+}
+
+type cronField map[int]bool
+
+func parseCronSchedule(expr string) (cronSchedule, error) {
+	fields := strings.Fields(expr)
+	if len(fields) != 5 {
+		return cronSchedule{}, fmt.Errorf("cron expression must have 5 fields")
+	}
+
+	minutes, _, err := parseCronField(fields[0], 0, 59, false)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("minute field: %w", err)
+	}
+	hours, _, err := parseCronField(fields[1], 0, 23, false)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("hour field: %w", err)
+	}
+	days, dayStar, err := parseCronField(fields[2], 1, 31, false)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("day field: %w", err)
+	}
+	months, _, err := parseCronField(fields[3], 1, 12, false)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("month field: %w", err)
+	}
+	weekdays, weekdayStar, err := parseCronField(fields[4], 0, 7, true)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("weekday field: %w", err)
+	}
+
+	return cronSchedule{
+		minutes:     minutes,
+		hours:       hours,
+		days:        days,
+		months:      months,
+		weekdays:    weekdays,
+		dayStar:     dayStar,
+		weekdayStar: weekdayStar,
+	}, nil
+}
+
+func parseCronField(field string, minValue, maxValue int, normalizeSunday bool) (cronField, bool, error) {
+	values := make(cronField)
+	isStar := field == "*"
+	for _, part := range strings.Split(field, ",") {
+		if part == "" {
+			return nil, false, fmt.Errorf("empty list item")
+		}
+
+		step := 1
+		base := part
+		if strings.Contains(part, "/") {
+			stepParts := strings.Split(part, "/")
+			if len(stepParts) != 2 || stepParts[0] == "" || stepParts[1] == "" {
+				return nil, false, fmt.Errorf("invalid step %q", part)
+			}
+			base = stepParts[0]
+			parsedStep, err := strconv.Atoi(stepParts[1])
+			if err != nil || parsedStep <= 0 {
+				return nil, false, fmt.Errorf("invalid step %q", part)
+			}
+			step = parsedStep
+		}
+
+		start, end, err := cronRange(base, minValue, maxValue)
+		if err != nil {
+			return nil, false, err
+		}
+		for value := start; value <= end; value += step {
+			normalized := value
+			if normalizeSunday && normalized == 7 {
+				normalized = 0
+			}
+			values[normalized] = true
+		}
+	}
+
+	return values, isStar, nil
+}
+
+func cronRange(base string, minValue, maxValue int) (int, int, error) {
+	if base == "*" {
+		return minValue, maxValue, nil
+	}
+	if strings.Contains(base, "-") {
+		rangeParts := strings.Split(base, "-")
+		if len(rangeParts) != 2 || rangeParts[0] == "" || rangeParts[1] == "" {
+			return 0, 0, fmt.Errorf("invalid range %q", base)
+		}
+		start, err := strconv.Atoi(rangeParts[0])
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid range start %q", base)
+		}
+		end, err := strconv.Atoi(rangeParts[1])
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid range end %q", base)
+		}
+		if start > end {
+			return 0, 0, fmt.Errorf("range start is greater than end %q", base)
+		}
+		if start < minValue || end > maxValue {
+			return 0, 0, fmt.Errorf("range %q is out of bounds %d-%d", base, minValue, maxValue)
+		}
+		return start, end, nil
+	}
+
+	value, err := strconv.Atoi(base)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid value %q", base)
+	}
+	if value < minValue || value > maxValue {
+		return 0, 0, fmt.Errorf("value %q is out of bounds %d-%d", base, minValue, maxValue)
+	}
+	return value, value, nil
+}
+
+func (s cronSchedule) next(after time.Time) time.Time {
+	next := after.Truncate(time.Minute).Add(time.Minute)
+	limit := next.AddDate(5, 0, 0)
+	for next.Before(limit) {
+		if s.matches(next) {
+			return next
+		}
+		next = next.Add(time.Minute)
+	}
+	return time.Time{}
+}
+
+func (s cronSchedule) matches(t time.Time) bool {
+	weekday := int(t.Weekday())
+	dayMatches := s.days[t.Day()]
+	weekdayMatches := s.weekdays[weekday]
+	switch {
+	case !s.dayStar && !s.weekdayStar:
+		if !dayMatches && !weekdayMatches {
+			return false
+		}
+	case !dayMatches || !weekdayMatches:
+		return false
+	}
+
+	return s.minutes[t.Minute()] &&
+		s.hours[t.Hour()] &&
+		s.months[int(t.Month())]
+}
+
+func startScheduleJobs(execDir string) error {
+	var firstErr error
+	for name, apiConfig := range sqlFiles {
+		if getAPIType(apiConfig) != apiTypeSchedule {
+			continue
+		}
+
+		scriptPath := strings.TrimSpace(apiConfig.Script)
+		triggerType := strings.TrimSpace(apiConfig.Trigger.Type)
+		triggerValue := strings.TrimSpace(apiConfig.Trigger.Value)
+
+		if scriptPath == "" {
+			err := fmt.Errorf("schedule %s: script is missing", name)
+			log.Print(err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if triggerType != "cron" {
+			err := fmt.Errorf("schedule %s: unsupported trigger type %q", name, triggerType)
+			log.Print(err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		schedule, err := parseCronSchedule(triggerValue)
+		if err != nil {
+			err = fmt.Errorf("schedule %s: invalid cron trigger %q: %w", name, triggerValue, err)
+			log.Print(err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+
+		scriptAbs := scriptPath
+		if !filepath.IsAbs(scriptPath) {
+			scriptAbs = filepath.Join(execDir, scriptPath)
+		}
+
+		cfg := scheduleJobConfig{
+			name:        name,
+			scriptPath:  scriptAbs,
+			trigger:     apiConfig.Trigger,
+			description: apiConfig.Description,
+			schedule:    schedule,
+		}
+
+		log.Printf("Starting schedule job %s with cron %q", cfg.name, cfg.trigger.Value)
+		go runScheduleJob(cfg)
+	}
+
+	return firstErr
+}
+
+func runScheduleJob(cfg scheduleJobConfig) {
+	for {
+		next := cfg.schedule.next(time.Now())
+		if next.IsZero() {
+			log.Printf("Schedule job %s has no next run time", cfg.name)
+			return
+		}
+
+		log.Printf("Schedule job %s next run at %s", cfg.name, next.Format(time.RFC3339))
+		timer := time.NewTimer(time.Until(next))
+		<-timer.C
+
+		params := map[string]interface{}{
+			"nyan_job_name":              cfg.name,
+			"nyan_schedule_trigger_type": cfg.trigger.Type,
+			"nyan_schedule_trigger":      cfg.trigger.Value,
+			"nyan_schedule_time":         next.Format(time.RFC3339),
+		}
+		result, err := runScript([]string{cfg.scriptPath}, params)
+		if err != nil {
+			log.Printf("Schedule job %s failed: %v", cfg.name, err)
+			continue
+		}
+		log.Printf("Schedule job %s completed: %s", cfg.name, result)
+	}
 }
 
 // startWebSocketClients は api.json に定義された ws_client を起動する。


### PR DESCRIPTION
- `type: "public"` による公開ファイル配信APIを追加
- `paramCheck` / `outCheck` を追加し、入力チェックと出力前チェックを分離
- `check` は互換用エイリアスとして維持
- `type: "schedule"` と cron 形式の定期実行ジョブを追加
- JSON-RPC、内部API呼び出し、script / SQL 実行時にも `outCheck` を適用
- Go 1.26.3 対応、および deprecated な `ioutil` 利用を `os` / `io` に置き換え
- README を v0.0.19 の機能内容に合わせて大幅更新
- schedule 動作確認用 `javascript/schedule_debug.js` を追加

